### PR TITLE
Set proper EFILoginHiDPI and UIScale parameter

### DIFF
--- a/CLOVER/config.plist
+++ b/CLOVER/config.plist
@@ -181,6 +181,13 @@
 		<key>Timeout</key>
 		<integer>2</integer>
 	</dict>
+	<key>BootGraphics</key>
+	<dict>
+		<key>EFILoginHiDPI</key>
+		<integer>0</integer>
+		<key>UIScale</key>
+		<integer>1</integer>
+	</dict>
 	<key>CPU</key>
 	<dict>
 		<key>HWPEnable</key>

--- a/Deploy.sh
+++ b/Deploy.sh
@@ -2099,7 +2099,18 @@ function main()
         _PRINT_MSG "--->: ${BLUE}Installing audio...${OFF}"
         _tidy_exec "install_audio" "Install audio"
     fi
-
+    
+    # Set EFILoginHiDPI & UIScale
+    if [[ $gHorizontalRez -gt 1920 || $gSystemHorizontalRez -gt 1920 ]];
+    _PRINT_MSG "--->: ${BLUE}Setting EFILoginHiDPI & UIScale...${OFF}"
+    then
+      ${doCommands[1]} "Set :BootGraphics:EFILoginHiDPI 1" "${config_plist}"
+      ${doCommands[1]} "Set :BootGraphics:UIScale 2" "${config_plist}"
+    else
+      ${doCommands[1]} "Set :BootGraphics:EFILoginHiDPI 0" "${config_plist}"
+      ${doCommands[1]} "Set :BootGraphics:UIScale 1" "${config_plist}"
+    fi
+    
     #
     # Patch IOKit/CoreDisplay.
     #


### PR DESCRIPTION
Set proper EFILoginHiDPI and UIScale parameter based on screen resolution so we can see a bigger Apple logo on 3k/4k screen during early stage pf boot.